### PR TITLE
Refactor Test-PSEnvironment

### DIFF
--- a/src/public/Enable-Tls12.Tests.ps1
+++ b/src/public/Enable-Tls12.Tests.ps1
@@ -1,17 +1,12 @@
 ﻿Describe 'Unit/Integration Tests' {
     BeforeAll {
         . $PSScriptRoot/Enable-Tls12.ps1
+        . $PSScriptRoot/Test-IsAdmin.ps1
         . $PSScriptRoot/Test-PSEnvironment.ps1
         . $PSScriptRoot/Start-Timeout
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::SystemDefault
 
-        try {
-            Test-PSEnvironment -CheckAdmin $true
-            $script:isAdmin = $true
-        }
-        catch {
-            $script:isAdmin = $false
-        }
+        $script:isAdmin = Test-IsAdmin
     }
 
     It 'should change TLS of the current session to 1.2' {
@@ -21,7 +16,7 @@
 
     Context 'When running in a non-admin console' {
         BeforeAll {
-            Mock Test-PSEnvironment { throw }
+            Mock Test-IsAdmin { $false }
             Mock Start-Process
         }
 

--- a/src/public/Enable-Tls12.ps1
+++ b/src/public/Enable-Tls12.ps1
@@ -30,7 +30,7 @@ function Enable-Tls12 {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
     if ($Persist) {
-        Test-PSEnvironment -CheckAdmin $true -ErrorAction Stop
+        Test-PSEnvironment -CheckAdmin -Exit
         $psRegPaths = (
             'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Client',
             'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server'

--- a/src/public/Set-EnvironmentVariable.Tests.ps1
+++ b/src/public/Set-EnvironmentVariable.Tests.ps1
@@ -3,19 +3,14 @@
 param()
 Describe 'Unit Tests' -Tag 'Unit' {
     BeforeAll {
-        $script:isAdmin = $true
-        try {
-            Test-PSEnvironment -ErrorAction SilentlyContinue
-        }
-        catch {
-            $script:isAdmin = $false
-        }
-        Write-Host -Object "##[info] Running tests as admin: $($script:isAdmin)"
-
         . $PSScriptRoot/Get-PSVersion.ps1
         . $PSScriptRoot/Get-EnvironmentVariable.ps1
+        . $PSScriptRoot/Test-IsAdmin.ps1
         . $PSScriptRoot/Test-PSEnvironment.ps1
         . $PSScriptRoot/Set-EnvironmentVariable.ps1
+
+        $script:isAdmin = Test-IsAdmin
+        Write-Host -Object "##[info] Running tests as admin: $($script:isAdmin)"
 
         <#
         .SYNOPSIS
@@ -258,13 +253,7 @@ Describe 'Unit Tests' -Tag 'Unit' {
 
 Describe 'Integration Tests' -Tag 'Integration' {
     BeforeDiscovery {
-        try {
-            Test-PSEnvironment -ErrorAction SilentlyContinue
-            $script:isAdmin = $true
-        }
-        catch {
-            $script:isAdmin = $false
-        }
+        $script:isAdmin = Test-IsAdmin
 
         $script:allScopes = @(
             @{ Scope = 'Process' },
@@ -280,6 +269,7 @@ Describe 'Integration Tests' -Tag 'Integration' {
         Write-Host -Object "##[info] Running tests as admin: $($script:isAdmin)"
 
         . $PSScriptRoot/Get-PSVersion.ps1
+        . $PSScriptRoot/Test-IsAdmin.ps1
         . $PSScriptRoot/Get-EnvironmentVariable.ps1
         . $PSScriptRoot/Test-PSEnvironment.ps1
         . $PSScriptRoot/Set-EnvironmentVariable.ps1

--- a/src/public/Set-EnvironmentVariable.ps1
+++ b/src/public/Set-EnvironmentVariable.ps1
@@ -60,7 +60,7 @@ function Set-EnvironmentVariable {
 
     begin {
         if ($Scope -eq 'Machine') {
-            Test-PSEnvironment -ErrorAction Stop
+            Test-PSEnvironment -CheckAdmin -Exit
         }
     }
 

--- a/src/public/Stop-DevProcess.Tests.ps1
+++ b/src/public/Stop-DevProcess.Tests.ps1
@@ -1,17 +1,12 @@
 ﻿Describe 'Integration Tests' -Skip:(!$script:isAdmin) {
     BeforeDiscovery {
-        $script:isAdmin = try {
-            Test-PSEnvironment
-            $true
-        }
-        catch {
-            $false
-        }
+        $script:isAdmin = Test-IsAdmin
     }
 
     BeforeAll {
         . $PSScriptRoot/Stop-ProcessTree.ps1
         . $PSScriptRoot/Stop-DevProcess.ps1
+        . $PSScriptRoot/Test-IsAdmin.ps1
         . $PSScriptRoot/Test-PSEnvironment.ps1
         . $PSScriptRoot/Get-PSVersion.ps1
 

--- a/src/public/Stop-DevProcess.ps1
+++ b/src/public/Stop-DevProcess.ps1
@@ -36,7 +36,7 @@ function Stop-DevProcess {
         '*chromedriver'
     )
 
-    Test-PSEnvironment
+    Test-PSEnvironment -CheckAdmin -Exit
     foreach ($processName in $Optional) {
         $processes = @( Get-Process -Name $processName -ErrorAction SilentlyContinue )
         foreach ($process in $processes) {

--- a/src/public/Test-IsAdmin.ps1
+++ b/src/public/Test-IsAdmin.ps1
@@ -1,0 +1,21 @@
+<#
+.SYNOPSIS
+Tests whether the current console is running with admin priviledges.
+
+.DESCRIPTION
+Tests whether the current console is running with admin priviledges.
+
+.EXAMPLE
+Test-IsAdmin
+
+.NOTES
+N/A
+#>
+function Test-IsAdmin {
+    [OutputType([Bool])]
+    [CmdletBinding()]
+    param ()
+
+    $currentUser = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+    $currentUser.IsInRole([Security.Principal.WindowsBuiltInRole]'Administrator')
+}

--- a/src/public/Test-PSEnvironment.Tests.ps1
+++ b/src/public/Test-PSEnvironment.Tests.ps1
@@ -1,5 +1,6 @@
 ﻿Describe 'Unit Tests' -Tag 'Unit' {
     BeforeAll {
+        . $PSScriptRoot/Test-IsAdmin.ps1
         . $PSScriptRoot/Get-PSVersion.ps1
         . $PSScriptRoot/Test-PSEnvironment.ps1
 
@@ -9,17 +10,65 @@
     }
 
     It 'should pass when the version is in range' {
-        { Test-PSEnvironment -MinimumVersion 5.0.0 -MaximumVersion 7.0.0 -CheckAdmin $false } |
+        Test-PSEnvironment -MinimumVersion 5.0.0 -MaximumVersion 7.0.0 |
+            Should -Be $true
+    }
+
+    It 'should not throw when the version is in range and -Exit is used' {
+        { Test-PSEnvironment -MinimumVersion 5.0.0 -MaximumVersion 7.0.0 -Exit } |
             Should -Not -Throw
     }
 
-    It 'should throw when the version is under the minimum' {
-        { Test-PSEnvironment -MinimumVersion 5.2.0 -MaximumVersion 7.0.0 -CheckAdmin $false } |
-            Should -Throw 'The minimum version*'
+    It 'should fail when the version is under the minimum' {
+        Test-PSEnvironment -MinimumVersion 5.2.0 -MaximumVersion 7.0.0 |
+            Should -Be $false
+
+        { Test-PSEnvironment -MinimumVersion 5.2.0 -MaximumVersion 7.0.0 } |
+            Should -Not -Throw
     }
 
-    It 'should throw when the version over the maximum' {
-        { Test-PSEnvironment -MinimumVersion 5.0.0 -MaximumVersion 5.1.5554 -CheckAdmin $false } |
-            Should -Throw 'The maximum version*'
+    It 'should fail when the version over the maximum' {
+        Test-PSEnvironment -MinimumVersion 5.0.0 -MaximumVersion 5.1.5554 |
+            Should -Be $false
+
+        { Test-PSEnvironment -MinimumVersion 5.0.0 -MaximumVersion 5.1.5554 } |
+            Should -Not -Throw
+    }
+
+    It 'should throw when the version is out of range and -Exit is used' {
+        { Test-PSEnvironment -MinimumVersion 5.0.0 -MaximumVersion 5.1.5554 -Exit } |
+            Should -Throw
+    }
+
+    Context 'When the current host has admin rights' {
+        BeforeAll {
+            Mock Test-IsAdmin {
+                $true
+            }
+        }
+
+        It 'should pass when -CheckAdmin is used' {
+            Test-PSEnvironment -CheckAdmin | Should -Be $true
+        }
+
+        It 'should not throw when -CheckAdmin and -Exit are used' {
+            { Test-PSEnvironment -CheckAdmin -Exit } | Should -Not -Throw
+        }
+    }
+
+    Context 'When the current host does not have admin rights' {
+        BeforeAll {
+            Mock Test-IsAdmin {
+                $false
+            }
+        }
+
+        It 'should fail when -CheckAdmin is used' {
+            Test-PSEnvironment -CheckAdmin | Should -Be $false
+        }
+
+        It 'should throw when -CheckAdmin and -Exit are used' {
+            { Test-PSEnvironment -CheckAdmin -Exit } | Should -Throw
+        }
     }
 }

--- a/src/public/Uninstall-ProgramByName.Tests.ps1
+++ b/src/public/Uninstall-ProgramByName.Tests.ps1
@@ -1,16 +1,11 @@
 ﻿Describe 'Integration Tests' -Tag 'Integration' -Skip:(!$script:isAdmin) {
     BeforeDiscovery {
-        $script:isAdmin = try {
-            Test-PSEnvironment
-            $true
-        }
-        catch {
-            $false
-        }
+        $script:isAdmin = Test-IsAdmin
     }
 
     BeforeAll {
         . $PSScriptRoot/Get-PSVersion.ps1
+        . $PSScriptRoot/Test-IsAdmin.ps1
         . $PSScriptRoot/Test-PSEnvironment.ps1
         . $PSScriptRoot/Uninstall-ProgramByName.ps1
 

--- a/src/public/Uninstall-ProgramByName.ps1
+++ b/src/public/Uninstall-ProgramByName.ps1
@@ -25,7 +25,7 @@ function Uninstall-ProgramByName {
     )
 
     begin {
-        Test-PSEnvironment -MinimumVersion 5.1
+        Test-PSEnvironment -MinimumVersion 5.1 -CheckAdmin -Exit
     }
 
     process {


### PR DESCRIPTION
- Refactor the portion of `Test-PSEnvironment` that checks for admin privileges into its own function, `Test-IsAdmin`
- Adjust logic to only return True/False as expected from `Test-*` functions and to only throw when `-Exit` is used.